### PR TITLE
Writer: initial implementation

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -1,3 +1,7 @@
+/* stdlogtoapex is a package that provides an implementation of
+/* io.Writer that can be used to redirect log output from the standard
+/* libraries log package via github.com/apex/log.
+*/
 package stdlogtoapex
 
 import (
@@ -6,6 +10,9 @@ import (
 	alog "github.com/apex/log"
 )
 
+// Writer is a struct that implements the io.Writer interface and can,
+// therefore, be passed into log.SetOutput.  Writer must always be
+// constructed by called NewWriter.
 type Writer struct {
 	prefixLen int
 }
@@ -14,13 +21,18 @@ func (w *Writer) stripDatePrefix(p []byte) string {
 	return string(p[w.prefixLen:])
 }
 
+// Write implements the io.Writer interface for Writer.  Log messages
+// output via this method will have their date and time information
+// stripped (apex log will have its own) .
 func (w *Writer) Write(p []byte) (n int, err error) {
 	msg := w.stripDatePrefix(p)
 	alog.Info(msg)
 	return len(p), nil
 }
 
-func NewWriter(level alog.Level, handler alog.Handler) *Writer {
+// NewWriter creates a new Writer that can be passed to the SetOutput
+// function in the log package from the standard library.
+func NewWriter() *Writer {
 	var prefixLen int
 
 	flags := log.Flags()

--- a/writer_test.go
+++ b/writer_test.go
@@ -10,13 +10,13 @@ import (
 )
 
 func TestNewWriter(t *testing.T) {
-	var _ io.Writer = NewWriter(nil)
+	var _ io.Writer = NewWriter()
 }
 
 func TestSetOutputToWriter(t *testing.T) {
 	handler := memory.New()
 	alog.SetHandler(handler)
-	writer := NewWriter(handler)
+	writer := NewWriter()
 	log.SetOutput(writer)
 	log.Print("Hello!")
 	if len(handler.Entries) != 1 {


### PR DESCRIPTION
This PR creates an implementation of `io.Writer` that can be passed to `log.SetOutput` in order to route log messages from the `log` package via github.com/apex/log. 

Everything gets logged at Info level, I'm not sure there's a solution. 

Fixes avct/birdseed#3047